### PR TITLE
Remove render

### DIFF
--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/AbstractPhysicsControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/AbstractPhysicsControl.java
@@ -200,9 +200,6 @@ public abstract class AbstractPhysicsControl implements PhysicsControl {
     public void update(float tpf) {
     }
 
-    public void render(RenderManager rm, ViewPort vp) {
-    }
-
     public void setPhysicsSpace(PhysicsSpace space) {
         if (space == null) {
             if (this.space != null) {

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/BetterCharacterControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/BetterCharacterControl.java
@@ -151,10 +151,6 @@ public class BetterCharacterControl extends AbstractPhysicsControl implements Ph
         applyPhysicsTransform(location, rotation);
     }
 
-    @Override
-    public void render(RenderManager rm, ViewPort vp) {
-        super.render(rm, vp);
-    }
 
     /**
      * Used internally, don't call manually

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/CharacterControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/CharacterControl.java
@@ -171,8 +171,6 @@ public class CharacterControl extends PhysicsCharacter implements PhysicsControl
         }
     }
 
-    public void render(RenderManager rm, ViewPort vp) {
-    }
 
     public void setPhysicsSpace(PhysicsSpace space) {
         if (space == null) {

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/GhostControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/GhostControl.java
@@ -144,8 +144,6 @@ public class GhostControl extends PhysicsGhostObject implements PhysicsControl {
         setPhysicsRotation(getSpatialRotation());
     }
 
-    public void render(RenderManager rm, ViewPort vp) {
-    }
 
     public void setPhysicsSpace(PhysicsSpace space) {
         if (space == null) {

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/KinematicRagdollControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/KinematicRagdollControl.java
@@ -900,15 +900,6 @@ public class KinematicRagdollControl extends AbstractPhysicsControl implements P
         return null;
     }
 
-    /**
-     * For internal use only specific render for the ragdoll(if debugging)
-     *
-     * @param rm
-     * @param vp
-     */
-    @Override
-    public void render(RenderManager rm, ViewPort vp) {
-    }
 
     public Control cloneForSpatial(Spatial spatial) {
         KinematicRagdollControl control = new KinematicRagdollControl(preset, weightThreshold);

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/RigidBodyControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/RigidBodyControl.java
@@ -227,8 +227,6 @@ public class RigidBodyControl extends PhysicsRigidBody implements PhysicsControl
         }
     }
 
-    public void render(RenderManager rm, ViewPort vp) {
-    }
 
     public void setPhysicsSpace(PhysicsSpace space) {
         if (space == null) {

--- a/jme3-bullet/src/common/java/com/jme3/bullet/control/VehicleControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/control/VehicleControl.java
@@ -197,8 +197,6 @@ public class VehicleControl extends PhysicsVehicle implements PhysicsControl {
         }
     }
 
-    public void render(RenderManager rm, ViewPort vp) {
-    }
 
     public void setPhysicsSpace(PhysicsSpace space) {
         createVehicle(space);

--- a/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletCharacterDebugControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletCharacterDebugControl.java
@@ -86,7 +86,4 @@ public class BulletCharacterDebugControl extends AbstractPhysicsDebugControl {
         geom.setLocalScale(body.getCollisionShape().getScale());
     }
 
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
-    }
 }

--- a/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletGhostObjectDebugControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletGhostObjectDebugControl.java
@@ -88,7 +88,4 @@ public class BulletGhostObjectDebugControl extends AbstractPhysicsDebugControl {
         geom.setLocalScale(body.getCollisionShape().getScale());
     }
 
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
-    }
 }

--- a/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletJointDebugControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletJointDebugControl.java
@@ -100,7 +100,4 @@ public class BulletJointDebugControl extends AbstractPhysicsDebugControl {
         arrowB.setArrowExtent(body.getPivotB());
     }
 
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
-    }
 }

--- a/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletRigidBodyDebugControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletRigidBodyDebugControl.java
@@ -90,8 +90,4 @@ public class BulletRigidBodyDebugControl extends AbstractPhysicsDebugControl {
         applyPhysicsTransform(body.getPhysicsLocation(location), body.getPhysicsRotation(rotation));
         geom.setLocalScale(body.getCollisionShape().getScale());
     }
-
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
-    }
 }

--- a/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletVehicleDebugControl.java
+++ b/jme3-bullet/src/common/java/com/jme3/bullet/debug/BulletVehicleDebugControl.java
@@ -136,7 +136,4 @@ public class BulletVehicleDebugControl extends AbstractPhysicsDebugControl {
         applyPhysicsTransform(body.getPhysicsLocation(location), body.getPhysicsRotation(rotation));
     }
 
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
-    }
 }

--- a/jme3-core/src/main/java/com/jme3/animation/AnimControl.java
+++ b/jme3-core/src/main/java/com/jme3/animation/AnimControl.java
@@ -338,12 +338,6 @@ public final class AnimControl extends AbstractControl implements Cloneable {
         }
     }
 
-    /**
-     * Internal use only.
-     */
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
-    }
 
     @Override
     public void write(JmeExporter ex) throws IOException {

--- a/jme3-core/src/main/java/com/jme3/animation/EffectTrack.java
+++ b/jme3-core/src/main/java/com/jme3/animation/EffectTrack.java
@@ -116,9 +116,6 @@ public class EffectTrack implements ClonableTrack {
             }
         }
 
-        @Override
-        protected void controlRender(RenderManager rm, ViewPort vp) {
-        }
 
         @Override
         public Control cloneForSpatial(Spatial spatial) {

--- a/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
+++ b/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
@@ -43,6 +43,7 @@ import com.jme3.scene.*;
 import com.jme3.scene.VertexBuffer.Type;
 import com.jme3.scene.control.AbstractControl;
 import com.jme3.scene.control.Control;
+import com.jme3.scene.control.RenderControl;
 import com.jme3.shader.VarType;
 import com.jme3.util.SafeArrayList;
 import com.jme3.util.TempVars;
@@ -63,7 +64,7 @@ import java.util.logging.Logger;
  *
  * @author Rémy Bouquet Based on AnimControl by Kirill Vainer
  */
-public class SkeletonControl extends AbstractControl implements Cloneable {
+public class SkeletonControl extends AbstractControl implements Cloneable, RenderControl {
 
     /**
      * The skeleton of the model.
@@ -262,6 +263,10 @@ public class SkeletonControl extends AbstractControl implements Cloneable {
     }
 
     public void render(RenderManager rm, ViewPort vp) {
+    	if(!enabled){
+    		return;
+    	}
+    	
         if (!wasMeshUpdated) {
             updateTargetsAndMaterials(spatial);
             

--- a/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
+++ b/jme3-core/src/main/java/com/jme3/animation/SkeletonControl.java
@@ -261,9 +261,7 @@ public class SkeletonControl extends AbstractControl implements Cloneable {
         }
     }
 
-    
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
+    public void render(RenderManager rm, ViewPort vp) {
         if (!wasMeshUpdated) {
             updateTargetsAndMaterials(spatial);
             

--- a/jme3-core/src/main/java/com/jme3/app/StatsView.java
+++ b/jme3-core/src/main/java/com/jme3/app/StatsView.java
@@ -131,7 +131,4 @@ public class StatsView extends Node implements Control {
         return enabled;
     }
 
-    public void render(RenderManager rm, ViewPort vp) {
-    }
-
 }

--- a/jme3-core/src/main/java/com/jme3/cinematic/events/MotionEvent.java
+++ b/jme3-core/src/main/java/com/jme3/cinematic/events/MotionEvent.java
@@ -443,8 +443,6 @@ public class MotionEvent extends AbstractCinematicEvent implements Control {
         return playState != PlayState.Stopped;
     }
 
-    public void render(RenderManager rm, ViewPort vp) {
-    }
 
     public void setSpatial(Spatial spatial) {
         this.spatial = spatial;

--- a/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
+++ b/jme3-core/src/main/java/com/jme3/effect/ParticleEmitter.java
@@ -53,6 +53,7 @@ import com.jme3.renderer.queue.RenderQueue.ShadowMode;
 import com.jme3.scene.Geometry;
 import com.jme3.scene.Spatial;
 import com.jme3.scene.control.Control;
+import com.jme3.scene.control.RenderControl;
 import com.jme3.util.TempVars;
 import java.io.IOException;
 
@@ -108,7 +109,7 @@ public class ParticleEmitter extends Geometry {
     private transient Vector3f temp = new Vector3f();
     private transient Vector3f lastPos;
 
-    public static class ParticleEmitterControl implements Control {
+    public static class ParticleEmitterControl implements Control, RenderControl {
 
         ParticleEmitter parentEmitter;
 

--- a/jme3-core/src/main/java/com/jme3/input/ChaseCamera.java
+++ b/jme3-core/src/main/java/com/jme3/input/ChaseCamera.java
@@ -596,14 +596,6 @@ public class ChaseCamera implements ActionListener, AnalogListener, Control {
         updateCamera(tpf);
     }
 
-    /**
-     * renders the camera control, should only be used internally
-     * @param rm
-     * @param vp
-     */
-    public void render(RenderManager rm, ViewPort vp) {
-        //nothing to render
-    }
 
     /**
      * Write the camera

--- a/jme3-core/src/main/java/com/jme3/scene/Spatial.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Spatial.java
@@ -51,6 +51,7 @@ import com.jme3.renderer.queue.RenderQueue.ShadowMode;
 import com.jme3.scene.control.BillboardControl;
 import com.jme3.scene.control.Control;
 import com.jme3.scene.control.LodControl;
+import com.jme3.scene.instancing.InstancedNode.InstancedNodeControl;
 import com.jme3.util.SafeArrayList;
 import com.jme3.util.TempVars;
 import java.io.IOException;
@@ -697,6 +698,10 @@ public abstract class Spatial implements Savable, Cloneable, Collidable, Cloneab
         	else if(c instanceof ParticleEmitterControl){
         		ParticleEmitterControl pc = (ParticleEmitterControl) c;
         		pc.render(rm, vp);
+        	}
+        	else if(c instanceof InstancedNodeControl){
+        		InstancedNodeControl ic = (InstancedNodeControl) c;
+        		ic.render(rm, vp);
         	}
             //c.render(rm, vp);
         }

--- a/jme3-core/src/main/java/com/jme3/scene/Spatial.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Spatial.java
@@ -51,7 +51,7 @@ import com.jme3.renderer.queue.RenderQueue.ShadowMode;
 import com.jme3.scene.control.BillboardControl;
 import com.jme3.scene.control.Control;
 import com.jme3.scene.control.LodControl;
-import com.jme3.scene.instancing.InstancedNode.InstancedNodeControl;
+import com.jme3.scene.control.RenderControl;
 import com.jme3.util.SafeArrayList;
 import com.jme3.util.TempVars;
 import java.io.IOException;
@@ -683,27 +683,9 @@ public abstract class Spatial implements Savable, Cloneable, Collidable, Cloneab
         }
 
         for (Control c : controls.getArray()) {
-        	if(c instanceof SkeletonControl){
-        		SkeletonControl sc = (SkeletonControl) c;
-        		sc.render(rm, vp);
+        	if(c instanceof RenderControl){
+        		((RenderControl) c).render(rm, vp);
         	}
-        	else if(c instanceof BillboardControl){
-        		BillboardControl bc = (BillboardControl) c;
-        		bc.render(rm, vp);
-        	}
-        	else if(c instanceof LodControl){
-        		LodControl lc = (LodControl) c;
-        		lc.render(rm, vp);
-        	}
-        	else if(c instanceof ParticleEmitterControl){
-        		ParticleEmitterControl pc = (ParticleEmitterControl) c;
-        		pc.render(rm, vp);
-        	}
-        	else if(c instanceof InstancedNodeControl){
-        		InstancedNodeControl ic = (InstancedNodeControl) c;
-        		ic.render(rm, vp);
-        	}
-            //c.render(rm, vp);
         }
     }
 

--- a/jme3-core/src/main/java/com/jme3/scene/Spatial.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Spatial.java
@@ -31,10 +31,12 @@
  */
 package com.jme3.scene;
 
+import com.jme3.animation.SkeletonControl;
 import com.jme3.asset.AssetKey;
 import com.jme3.asset.CloneableSmartAsset;
 import com.jme3.bounding.BoundingVolume;
 import com.jme3.collision.Collidable;
+import com.jme3.effect.ParticleEmitter.ParticleEmitterControl;
 import com.jme3.export.*;
 import com.jme3.light.Light;
 import com.jme3.light.LightList;
@@ -46,7 +48,9 @@ import com.jme3.renderer.ViewPort;
 import com.jme3.renderer.queue.RenderQueue;
 import com.jme3.renderer.queue.RenderQueue.Bucket;
 import com.jme3.renderer.queue.RenderQueue.ShadowMode;
+import com.jme3.scene.control.BillboardControl;
 import com.jme3.scene.control.Control;
+import com.jme3.scene.control.LodControl;
 import com.jme3.util.SafeArrayList;
 import com.jme3.util.TempVars;
 import java.io.IOException;
@@ -678,7 +682,23 @@ public abstract class Spatial implements Savable, Cloneable, Collidable, Cloneab
         }
 
         for (Control c : controls.getArray()) {
-            c.render(rm, vp);
+        	if(c instanceof SkeletonControl){
+        		SkeletonControl sc = (SkeletonControl) c;
+        		sc.render(rm, vp);
+        	}
+        	else if(c instanceof BillboardControl){
+        		BillboardControl bc = (BillboardControl) c;
+        		bc.render(rm, vp);
+        	}
+        	else if(c instanceof LodControl){
+        		LodControl lc = (LodControl) c;
+        		lc.render(rm, vp);
+        	}
+        	else if(c instanceof ParticleEmitterControl){
+        		ParticleEmitterControl pc = (ParticleEmitterControl) c;
+        		pc.render(rm, vp);
+        	}
+            //c.render(rm, vp);
         }
     }
 

--- a/jme3-core/src/main/java/com/jme3/scene/control/AbstractControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/AbstractControl.java
@@ -78,11 +78,6 @@ public abstract class AbstractControl implements Control {
     protected abstract void controlUpdate(float tpf);
 
     /**
-     * To be implemented in subclass.
-     */
-    protected abstract void controlRender(RenderManager rm, ViewPort vp);
-
-    /**
      *  Default implementation of cloneForSpatial() that
      *  simply clones the control and sets the spatial.
      *  <pre>
@@ -110,13 +105,6 @@ public abstract class AbstractControl implements Control {
             return;
 
         controlUpdate(tpf);
-    }
-
-    public void render(RenderManager rm, ViewPort vp) {
-        if (!enabled)
-            return;
-
-        controlRender(rm, vp);
     }
 
     public void write(JmeExporter ex) throws IOException {

--- a/jme3-core/src/main/java/com/jme3/scene/control/BillboardControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/BillboardControl.java
@@ -97,8 +97,7 @@ public class BillboardControl extends AbstractControl {
     protected void controlUpdate(float tpf) {
     }
 
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
+    public void render(RenderManager rm, ViewPort vp) {
         Camera cam = vp.getCamera();
         rotateBillboard(cam);
     }

--- a/jme3-core/src/main/java/com/jme3/scene/control/BillboardControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/BillboardControl.java
@@ -46,7 +46,7 @@ import com.jme3.scene.Node;
 import com.jme3.scene.Spatial;
 import java.io.IOException;
 
-public class BillboardControl extends AbstractControl {
+public class BillboardControl extends AbstractControl implements RenderControl {
 
     private Matrix3f orient;
     private Vector3f look;
@@ -98,6 +98,10 @@ public class BillboardControl extends AbstractControl {
     }
 
     public void render(RenderManager rm, ViewPort vp) {
+    	if(!enabled){
+    		return;
+    	}
+    	
         Camera cam = vp.getCamera();
         rotateBillboard(cam);
     }

--- a/jme3-core/src/main/java/com/jme3/scene/control/CameraControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/CameraControl.java
@@ -131,10 +131,6 @@ public class CameraControl extends AbstractControl {
         }
     }
 
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
-        // nothing to do
-    }
 
     @Override
     public Control cloneForSpatial(Spatial newSpatial) {

--- a/jme3-core/src/main/java/com/jme3/scene/control/Control.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/Control.java
@@ -65,13 +65,4 @@ public interface Control extends Savable {
      * @param tpf Time per frame.
      */
     public void update(float tpf);
-
-    /**
-     * Should be called prior to queuing the spatial by the RenderManager. This
-     * should not be called from user code.
-     *
-     * @param rm
-     * @param vp
-     */
-    public void render(RenderManager rm, ViewPort vp);
 }

--- a/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/LightControl.java
@@ -162,12 +162,6 @@ public class LightControl extends AbstractControl {
 
     }
 
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
-        // nothing to do
-    }
-
-    @Override
     public Control cloneForSpatial(Spatial newSpatial) {
         LightControl control = new LightControl(light, controlDir);
         control.setSpatial(newSpatial);

--- a/jme3-core/src/main/java/com/jme3/scene/control/LodControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/LodControl.java
@@ -146,7 +146,7 @@ public class LodControl extends AbstractControl implements Cloneable {
     protected void controlUpdate(float tpf) {
     }
 
-    protected void controlRender(RenderManager rm, ViewPort vp) {
+    public void render(RenderManager rm, ViewPort vp) {
         BoundingVolume bv = spatial.getWorldBound();
 
         Camera cam = vp.getCamera();

--- a/jme3-core/src/main/java/com/jme3/scene/control/LodControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/LodControl.java
@@ -56,7 +56,7 @@ import java.io.IOException;
  * and will update the spatial's LOD if the camera has moved by a specified
  * amount.
  */
-public class LodControl extends AbstractControl implements Cloneable {
+public class LodControl extends AbstractControl implements Cloneable, RenderControl{
 
     private float trisPerPixel = 1f;
     private float distTolerance = 1f;
@@ -147,6 +147,10 @@ public class LodControl extends AbstractControl implements Cloneable {
     }
 
     public void render(RenderManager rm, ViewPort vp) {
+    	if(!enabled){
+    		return;
+    	}
+    	
         BoundingVolume bv = spatial.getWorldBound();
 
         Camera cam = vp.getCamera();

--- a/jme3-core/src/main/java/com/jme3/scene/control/RenderControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/RenderControl.java
@@ -1,0 +1,15 @@
+package com.jme3.scene.control;
+
+import com.jme3.renderer.RenderManager;
+import com.jme3.renderer.ViewPort;
+
+/**
+ * Interface for Controls requiring render() methods
+ * @author wiebe
+ *
+ */
+public interface RenderControl extends Control {
+	
+	public void render(RenderManager rm, ViewPort vp);
+	
+}

--- a/jme3-core/src/main/java/com/jme3/scene/control/UpdateControl.java
+++ b/jme3-core/src/main/java/com/jme3/scene/control/UpdateControl.java
@@ -80,10 +80,6 @@ public class UpdateControl extends AbstractControl {
         } while (((task = taskQueue.poll()) != null));
     }
 
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
-        
-    }
 
     public Control cloneForSpatial(Spatial newSpatial) {
         UpdateControl control = new UpdateControl(); 

--- a/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedNode.java
+++ b/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedNode.java
@@ -106,7 +106,7 @@ public class InstancedNode extends GeometryGroupNode {
         }
     }
     
-    private static class InstancedNodeControl implements Control {
+    public static class InstancedNodeControl implements Control {
 
         private InstancedNode node;
         

--- a/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedNode.java
+++ b/jme3-core/src/main/java/com/jme3/scene/instancing/InstancedNode.java
@@ -41,6 +41,7 @@ import com.jme3.scene.Node;
 import com.jme3.scene.Spatial;
 import com.jme3.scene.UserData;
 import com.jme3.scene.control.Control;
+import com.jme3.scene.control.RenderControl;
 import com.jme3.export.JmeExporter;
 import com.jme3.export.JmeImporter;
 import com.jme3.material.MatParam;
@@ -106,7 +107,7 @@ public class InstancedNode extends GeometryGroupNode {
         }
     }
     
-    public static class InstancedNodeControl implements Control {
+    private static class InstancedNodeControl implements Control, RenderControl {
 
         private InstancedNode node;
         

--- a/jme3-core/src/main/resources/com/jme3/system/version.properties
+++ b/jme3-core/src/main/resources/com/jme3/system/version.properties
@@ -1,12 +1,12 @@
 # THIS IS AN AUTO-GENERATED FILE..
 # DO NOT MODIFY!
 build.date=2016-03-23
-git.revision=5503
+git.revision=5504
 git.branch=RemoveRender
-git.hash=d880d5ec8b28bd09eef3a17a7614eb91813894bf
-git.hash.short=d880d5e
+git.hash=7aa2e490bcd10c62f2eb10eb554ab63a504f9148
+git.hash.short=7aa2e49
 git.tag=null
-name.full=jMonkeyEngine 3.1-RemoveRender-5503
-version.full=3.1-RemoveRender-5503
+name.full=jMonkeyEngine 3.1-RemoveRender-5504
+version.full=3.1-RemoveRender-5504
 version.number=3.1.0
 version.tag=SNAPSHOT

--- a/jme3-core/src/main/resources/com/jme3/system/version.properties
+++ b/jme3-core/src/main/resources/com/jme3/system/version.properties
@@ -1,11 +1,12 @@
 # THIS IS AN AUTO-GENERATED FILE..
 # DO NOT MODIFY!
-build.date=1900-01-01
-git.revision=0
-git.branch=unknown
-git.hash=
-git.hash.short=
-git.tag=
-name.full=jMonkeyEngine 3.1.0-UNKNOWN
+build.date=2016-03-23
+git.revision=5502
+git.branch=RemoveRender
+git.hash=02b78558d6691db2f8053d48e30c27876f925f69
+git.hash.short=02b7855
+git.tag=null
+name.full=jMonkeyEngine 3.1-RemoveRender-5502
+version.full=3.1-RemoveRender-5502
 version.number=3.1.0
 version.tag=SNAPSHOT

--- a/jme3-core/src/main/resources/com/jme3/system/version.properties
+++ b/jme3-core/src/main/resources/com/jme3/system/version.properties
@@ -1,12 +1,12 @@
 # THIS IS AN AUTO-GENERATED FILE..
 # DO NOT MODIFY!
 build.date=2016-03-23
-git.revision=5502
+git.revision=5503
 git.branch=RemoveRender
-git.hash=02b78558d6691db2f8053d48e30c27876f925f69
-git.hash.short=02b7855
+git.hash=d880d5ec8b28bd09eef3a17a7614eb91813894bf
+git.hash.short=d880d5e
 git.tag=null
-name.full=jMonkeyEngine 3.1-RemoveRender-5502
-version.full=3.1-RemoveRender-5502
+name.full=jMonkeyEngine 3.1-RemoveRender-5503
+version.full=3.1-RemoveRender-5503
 version.number=3.1.0
 version.tag=SNAPSHOT

--- a/jme3-examples/src/main/java/jme3test/light/TestManyLightsSingle.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestManyLightsSingle.java
@@ -275,9 +275,5 @@ public class TestManyLightsSingle extends SimpleApplication {
             time += tpf;
             spatial.setLocalTranslation(origPos.x + FastMath.cos(time) * direction, origPos.y, origPos.z + FastMath.sin(time) * direction);
         }
-
-        @Override
-        protected void controlRender(RenderManager rm, ViewPort vp) {
-        }
     }
 }

--- a/jme3-examples/src/main/java/jme3test/light/TestPssmShadow.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestPssmShadow.java
@@ -249,9 +249,6 @@ public class TestPssmShadow extends SimpleApplication implements ActionListener 
             time = 0;
         }
 
-        @Override
-        protected void controlRender(RenderManager rm, ViewPort vp) {
-        }
 
         public Control cloneForSpatial(Spatial spatial) {
             return null;

--- a/jme3-examples/src/main/java/jme3test/renderer/TestDepthStencil.java
+++ b/jme3-examples/src/main/java/jme3test/renderer/TestDepthStencil.java
@@ -94,9 +94,6 @@ public class TestDepthStencil extends SimpleApplication {
 		);
             }
 
-            @Override
-            protected void controlRender(RenderManager rm, ViewPort vp) {
-            }
         });
 
         //setup main scene

--- a/jme3-examples/src/main/java/jme3test/scene/TestSceneStress.java
+++ b/jme3-examples/src/main/java/jme3test/scene/TestSceneStress.java
@@ -153,10 +153,6 @@ public class TestSceneStress extends SimpleApplication {
             if( spatial != null ) {
                 spatial.rotate(rotate[0] * tpf, rotate[1] * tpf, rotate[2] * tpf);
             }
-        }
-
-        @Override
-        protected void controlRender( RenderManager rm, ViewPort vp ) {
-        }        
+        }     
     }  
 }

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/NormalRecalcControl.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/NormalRecalcControl.java
@@ -62,10 +62,6 @@ public class NormalRecalcControl extends AbstractControl {
         terrain.updateNormals();
     }
 
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
-
-    }
 
     public Control cloneForSpatial(Spatial spatial) {
         NormalRecalcControl control = new NormalRecalcControl(terrain);

--- a/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainLodControl.java
+++ b/jme3-terrain/src/main/java/com/jme3/terrain/geomipmap/TerrainLodControl.java
@@ -121,10 +121,6 @@ public class TerrainLodControl extends AbstractControl {
         lodCalculator = new DistanceLodCalculator(65, 2.7f); // a default calculator
     }
 
-    @Override
-    protected void controlRender(RenderManager rm, ViewPort vp) {
-    }
-
     /**
      * Set your own custom executor to be used. The control will use
      * this instead of creating its own.


### PR DESCRIPTION
Removes `render` from the `Controls` interface and all classes where its implementation was empty. 
A `ControlRender` interface was created to replace this for classes that should implement the `render` method.